### PR TITLE
Add implementation plan document

### DIFF
--- a/docs/03_実装計画.md
+++ b/docs/03_実装計画.md
@@ -1,0 +1,152 @@
+# 03_実装計画
+
+本書は「基本設計書」「テーブル設計書」に基づき、MVP実装の手順を**段階的なDB作成（マイグレーション）**を前提に整理したもの。Flutter（MVVM + Clean Architecture）と Supabase/Postgres を想定する。
+
+---
+
+## 1. 事前準備・方針確定
+
+1. **リポジトリ/環境確認**
+   - Supabase CLI と Flutter 環境を確認。
+   - `supabase` プロジェクト（ローカル or リモート）を確定。
+2. **マイグレーション方針**
+   - すべてのDDLは **Supabase migration** で管理。
+   - 依存関係が少ないテーブルから順に作成し、後段でFK追加やRLS追加を行う。
+3. **スキーマ命名/規約**
+   - UUIDは `gen_random_uuid()` を使用。
+   - テーブル/カラムは設計書の名称に一致させる。
+
+---
+
+## 2. DB実装（段階的なテーブル作成）
+
+### 2.1 マイグレーション設計（フェーズ分割）
+
+**フェーズ1: 認証基盤・ユーザー関連**
+- `users` テーブル作成
+- 主要インデックス追加（`firebase_uid` unique）
+
+**フェーズ2: チーム関連**
+- `teams` 作成
+- `team_members` 作成（`team_id`/`user_id` FK）
+- `(team_id, user_id)` の unique 制約
+
+**フェーズ3: プレイヤーと試合**
+- `players` 作成（`team_id`/`user_id`/`created_by` FK）
+- `games` 作成（`home_team_id`/`away_team_id` FK）
+
+**フェーズ4: 打席イベント/Claim/監査ログ**
+- `plate_appearances` 作成（`game_id`/`batter_player_id`/`pitcher_player_id` FK）
+- `claims` 作成（`player_id`/`claimed_user_id` FK）
+- `audit_logs` 作成（FKは `actor_user_id` のみ）
+
+**フェーズ5: 集計ビュー**
+- `v_matchup_batter_pitcher`
+- `v_matchup_team_team`
+
+**フェーズ6: RLSポリシー**
+- 参照/更新ポリシーをテーブル単位で実装
+- 段階的に「参照のみ」→「更新/削除」へ拡張
+
+---
+
+### 2.2 マイグレーション詳細（例）
+
+1. **初期マイグレーション**
+   - `users` 作成、`firebase_uid` に unique。
+2. **チーム・メンバー**
+   - `teams` → `team_members` の順で作成。
+3. **プレイヤー/試合**
+   - `players`（仮プレイヤー対応）
+   - `games`（`status` default `draft`）
+4. **打席イベント/Claim/監査ログ**
+   - `plate_appearances`、`claims`、`audit_logs` を追加。
+5. **ビュー作成**
+   - 集計定義（`AB`, `H`, `HR` 等）を SQL View として実装。
+6. **RLS/インデックス**
+   - RLS: `teams/team_members/games/plate_appearances/players/claims` を対象。
+   - 主要参照カラム（`game_id`, `batter_player_id`, `pitcher_player_id`）に索引付与。
+
+---
+
+## 3. アプリ実装（MVP機能の段階的実装）
+
+### 3.1 認証・プロフィール（M1）
+1. Supabase Auth（Email/Password）導入。
+2. `users` テーブルと連動したプロフィール作成/更新。
+3. ViewModel/Repository/UseCaseの雛形作成。
+
+### 3.2 チーム管理（M1）
+1. チーム作成画面・API。
+2. `team_members` 追加（Owner/Admin/Member）。
+3. 招待コード生成/参加フロー。
+
+### 3.3 試合管理（M1）
+1. 試合作成（Draft）。
+2. 試合一覧/詳細取得。
+3. 確定（Final）への状態変更。
+
+### 3.4 打席イベント入力（M2）
+1. 打席入力画面（MVP簡易）。
+2. `plate_appearances` 登録。
+3. 結果コードの選択UI（`result_type`, `result_detail`）。
+
+### 3.5 集計表示（M2）
+1. `v_matchup_batter_pitcher` 参照。
+2. 直近N試合はクエリで取得。
+3. MVPでは SQL View + クライアント計算を併用。
+
+### 3.6 因縁カード（M3）
+1. 因縁詳細画面。
+2. カード生成（Canvas描画）。
+3. 共有機能（Share Sheet）。
+
+### 3.7 仮プレイヤー・Claim（M4）
+1. 仮プレイヤー作成（`players.user_id is null`）。
+2. Claim UI 追加 → `claims` 登録。
+3. Claim後のプロフィール統合。
+
+---
+
+## 4. RLSポリシー実装手順
+
+1. **参照ポリシー（最小）**
+   - 所属チーム/試合参加者のみ閲覧。
+2. **更新/削除ポリシー**
+   - `Owner/Admin` のみ編集可。
+   - `plate_appearances` は試合作成者 or Admin のみ変更。
+3. **監査ログ**
+   - 更新系APIで必ず `audit_logs` に記録。
+
+---
+
+## 5. テスト・検証
+
+1. **DB検証**
+   - マイグレーション実行順に `supabase db reset` で再構築。
+   - Seedデータを投入して基本クエリを確認。
+2. **ユースケース検証**
+   - ユーザー登録 → チーム参加 → 試合作成 → 打席入力 → 因縁表示までを通し確認。
+3. **RLS検証**
+   - チーム未所属ユーザーでアクセス拒否を確認。
+
+---
+
+## 6. 実装マイルストーン（基本設計との対応）
+
+- **M1**：認証 + チーム + 試合CRUD
+- **M2**：打席入力 + 集計ビュー
+- **M3**：因縁詳細 + カード生成 + 共有
+- **M4**：仮プレイヤー + Claim
+- **M5**：βテスト → 改善
+
+---
+
+## 7. 実装完了後の運用
+
+1. **DBマイグレーション運用**
+   - 変更は必ず migration で履歴管理。
+2. **データ再集計**
+   - 必要に応じて `plate_appearances` から集計ビュー再構築。
+3. **将来拡張**
+   - Edge Functions/AIテキスト生成、詳細スタッツ、通知機構。


### PR DESCRIPTION
### Motivation
- 実装を設計書に沿って段階的に進めるために、マイグレーション中心の実装計画を明確化する。 
- DBの段階的作成（フェーズ分割）とRLS導入手順を先に定義して、安全にリリースする運用を整える。 

### Description
- 新規ファイル `docs/03_実装計画.md` を追加し、フェーズごとのマイグレーション設計（`users` → `teams` → `players/games` → `plate_appearances/claims/audit_logs` → views → RLS）を記載した。 
- Flutter（MVVM + Clean Architecture）とSupabase/Postgresを想定したアプリ側の段階的実装（M1〜M5）と因縁カードなどの機能実装手順を示した。 
- RLSポリシー実装手順、テスト・検証手順（`supabase db reset` によるマイグレーション検証、シード投入、ユースケースの通し確認）および運用上の注意点を追記した。 

### Testing
- ドキュメント追加のみのため自動化テストは実行しておらず、変更はドキュメントに限定される。 
- マイグレーション/実装手順に沿った手順での検証を想定しており、実コードのマイグレーション適用後に `supabase db reset` とシードを用いた自動検証を推奨する。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69833ae978d083229f79f490865540db)