### PR TITLE
fix: 認証状態のロード中はスプラッシュに留まりログイン画面のちらつきを防止

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -120,6 +120,13 @@ final routerProvider = Provider<GoRouter>((ref) {
         return null;
       }
 
+      // 認証状態がまだ確定していない間はスプラッシュに留まる
+      // （StreamProviderの初回ロード中に/loginへ飛ばすとちらつきが発生するため）
+      if (authState != null && authState.isLoading) {
+        if (state.matchedLocation != '/splash') return '/splash';
+        return null;
+      }
+
       // スプラッシュから離れた後の認証リダイレクト
       final isLoggedIn = authState?.valueOrNull != null;
       final isAuthRoute =


### PR DESCRIPTION
StreamProviderの初回ロード時にauthState.valueOrNullがnullを返し、
ログイン済みユーザーでも一瞬/loginにリダイレクトされる問題を修正。
authStateがisLoadingの間はスプラッシュ画面に留まるようにした。

Closes #12

https://claude.ai/code/session_018i91cWTYmo3Kbs4zEgaCuH